### PR TITLE
Can now handle images with spaces in their path

### DIFF
--- a/instagram_filters/filter.py
+++ b/instagram_filters/filter.py
@@ -17,7 +17,7 @@ class Filter:
 	
 	def execute(self, command, **kwargs):
 		default = dict(
-			filename=self.filename,
+			filename = '\'' + self.filename + '\'',
 			width = self.image().size[0],
 			height = self.image().size[1]
 		)


### PR DESCRIPTION
First of all thanks a lot for this, it's great. It did not work for me out of the box, I had to fiddle with things, maybe because I'm using Python 3.

But  this is a small fix that I guess applies to your code too. It was crashing when my images had spaces in their names, this solved it for me.
